### PR TITLE
Remove unused Microsoft.Playwright.MSTest package from tests.

### DIFF
--- a/Snipster.Test/Snipster.Test.csproj
+++ b/Snipster.Test/Snipster.Test.csproj
@@ -13,9 +13,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Microsoft.Playwright.MSTest" Version="1.27.1">
-      <TreatAsUsed>true</TreatAsUsed>
-    </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
@@ -27,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Microsoft.Playwright.MSTest" />
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
     <Using Include="System.Text.RegularExpressions" />
     <Using Include="System.Threading.Tasks" />


### PR DESCRIPTION
﻿---
name: Pull Request
about: Submit code changes for review
title: Remove unused Microsoft.Playwright.MSTest from test project.
labels: `cleanup`
assignees: ''

---

> ⚠️ **Important:** Pull requests to `main` must originate from the `dev` branch and reflect a completed, reviewed, and tested development cycle. Do not open PRs directly to `main` for in-progress work — use the `dev` branch instead.

**Description**

Removes the unused Microsoft.Playwright.MSTest package from Snipster.Test. The project only uses MSTest for unit tests; Playwright was not used in any test code or documentation.

This simplifies the test project and avoids pulling in browser/E2E dependencies that are not part of this library’s test strategy.

Fixes # (issue)

**Changes introduced**
- Removed Microsoft.Playwright.MSTest package reference from Snipster.Test/Snipster.Test.csproj.
- Removed global Using for Microsoft.Playwright.MSTest.
- No breaking changes to the library or public API.

**Related issues**

- N/A

**Type of change**
- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Configuration change/update
- [ ] Documentation update

**How has this been tested?**

Please describe the tests that you ran to verify your changes.
- [x] dotnet restore and dotnet build on Snipster.Test succeed without Playwright.
- [x] dotnet test — existing MSTest unit tests pass.

**Checklist**
- [x] The code builds and runs locally
- [ ] Unit tests have been added/updated
- [ ] XML documentation is added for public methods
- [x] Follows consistent naming and code style

**Additional context**

Add any screenshots, notes, or context that reviewers might need.
